### PR TITLE
EVA-3267 - Use updated version of eva-accession-core that fixes ambiguous RestTemplate bean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>eva-accession-core</artifactId>
-            <version>0.6.19-SNAPSHOT</version>
+            <version>0.6.20-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
See [here](https://github.com/EBIvariation/eva-accession/pull/389#issue-1698673241)